### PR TITLE
Fix "guage" -> "gauge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ on busy VM.
 - `dec (key &key (rate) (client *client*))` - shortcut for `(counter key -1 ...)`
 - `timing (key value &key (rate) (client *client*))`
 - `with-timing ((key &optional (client '*client*)) &body body)` - executes body and collects execution time
-- `guage (key value &key (rate) (client *client*))`
+- `gauge (key value &key (rate) (client *client*))`
 - `set (key value &key (rate) (client *client*))`
 
 Sampling rate can be controlled using `*random-range*` parameter (default is 100). If set to 0 turns off sampling completely (equivalent of constant rate 1)
@@ -39,7 +39,7 @@ Given `statsd:*client*` is bound you can write something like this:
 Pipelining implemented using 'wrapper' client that gathers metrics, concatenates them and sends directly to the wrapped client transport. Currently CL-STATSD makes no effort to split pipelined data or otherwise respect/detect MTU.
 
 ## Error handling
-By default all errors simply ignored. You can customize this behaviour 
+By default all errors simply ignored. You can customize this behaviour
 by providing :error-handler strategy:
 ```lisp
 (let ((statsd:*client* (statsd:make-sync-client :error-handler :throw)))
@@ -63,7 +63,7 @@ Queues metrics. Useful for debugging, testing
 ```
 #### `sync`
 Calls transport synchronously
-#### `async` 
+#### `async`
 More like 'connection-as-a-service', runs in separate thread, all metrics queued first. To prevent queue from overgrowing async client understands throttling threshold (i.e. max queue length):
 ```lisp
 (let ((statsd:*client* (statsd:make-async-client :error-handler :throw

--- a/src/clients/base.lisp
+++ b/src/clients/base.lisp
@@ -52,7 +52,7 @@
 (defmethod serialize-metric ((metric (eql :timing)) key value rate)
   (serialize-metric% "ms" key value rate))
 
-(defmethod serialize-metric ((metric (eql :guage)) key value rate)
+(defmethod serialize-metric ((metric (eql :gauge)) key value rate)
   (serialize-metric% "g" key value rate))
 
 (defmethod serialize-metric ((metric (eql :set)) key value rate)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -9,7 +9,7 @@
            #:dec
            #:timing
            #:with-timing
-           #:guage
+           #:gauge
            #:set
            ;; transports
            #:transport-base

--- a/src/statsd.lisp
+++ b/src/statsd.lisp
@@ -14,8 +14,8 @@
 (defun timing (key value &key (rate) (client *client*))
   (send client :timing key value rate))
 
-(defun guage (key value &key (rate) (client *client*))
-  (send client :guage key value rate))
+(defun gauge (key value &key (rate) (client *client*))
+  (send client :gauge key value rate))
 
 (defun set (key value &key (rate) (client *client*))
   (send client :set key value rate))

--- a/t/serializer.lisp
+++ b/t/serializer.lisp
@@ -7,16 +7,16 @@
     (let ((statsd:*client* (statsd:make-capture-client :prefix "qwe")))
       (statsd:counter "qwe" 1)
       (is (statsd:capture-client.recv) "qwe.qwe:1|c")))
-  
+
   (subtest "Counter"
     (is (with-capture-client (statsd:counter "app.example" 3)) "app.example:3|c")
     (is (with-capture-client (statsd:inc "app.example")) "app.example:1|c")
     (is (with-capture-client (statsd:dec "app.example")) "app.example:-1|c")
     (is (with-capture-client (statsd:counter "app.example" 3 :rate 0.23)) "app.example:3|c|@0.23"))
-  
-  (subtest "Guage"
-    (is (with-capture-client (statsd:guage "app.example" 3)) "app.example:3|g")
-    (is (with-capture-client (statsd:guage "app.example" 3 :rate 0.23)) "app.example:3|g|@0.23"))
+
+  (subtest "Gauge"
+    (is (with-capture-client (statsd:gauge "app.example" 3)) "app.example:3|g")
+    (is (with-capture-client (statsd:gauge "app.example" 3 :rate 0.23)) "app.example:3|g|@0.23"))
 
   (subtest "Set"
     (is (with-capture-client (statsd:set "app.example" 3)) "app.example:3|s")


### PR DESCRIPTION
Hi! I've noticed that there's a typo in the readme but then it turned out that gauge has the same typo everywhere

Thank you for the library by the way - since it's my first time using Common Lisp I learned a lot from it 👍 